### PR TITLE
fix pytorch 2.0 optimizer no inf check error

### DIFF
--- a/nerfstudio/engine/optimizers.py
+++ b/nerfstudio/engine/optimizers.py
@@ -127,7 +127,8 @@ class Optimizers:
             if max_norm is not None:
                 grad_scaler.unscale_(optimizer)
                 torch.nn.utils.clip_grad_norm_(self.parameters[param_group], max_norm)
-            grad_scaler.step(optimizer)
+            if optimizer.param_groups[0]["params"][0].grad is not None:
+                grad_scaler.step(optimizer)
 
     def optimizer_step_all(self) -> None:
         """Run step for all optimizers."""


### PR DESCRIPTION
fix #1883 #1613.

The reason why there's no inf check is because proposal network did not compute gradient at some iteration step. And there is no need to do optimizer.step for proposal network's parameter.